### PR TITLE
Fix calling of bus_get_sync

### DIFF
--- a/pydbus/bus.py
+++ b/pydbus/bus.py
@@ -7,7 +7,7 @@ class Bus(OwnMixin, WatchMixin):
 	Type = Gio.BusType
 
 	def __init__(self, type:Type, timeout=10):
-		self.con = Gio.bus_get_sync(type)
+		self.con = Gio.bus_get_sync(type, None)
 		self.timeout = timeout
 
 	def get(self, bus_name, object_path=None):


### PR DESCRIPTION
Takes a cancellable parameter, but it can be None.

fixes #1

Signed-off-by: Andy Grover agrover@redhat.com
