### PR TITLE
Support asynchonous invocation and authorization of exported methods 

### DIFF
--- a/pydbus/authorization.py
+++ b/pydbus/authorization.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Anselm Kruis
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+
+"""
+A decorator for Polkit authorization
+"""
+
+from __future__ import print_function, absolute_import
+
+from gi.repository import GObject, GLib, Polkit, Gio
+import traceback
+import inspect
+import functools
+from pydbus import registration
+
+__all__ = ['PolkitAuthorization']
+
+
+class PolkitAuthorization(object):
+	@staticmethod
+	def NotAuthorizedError(message="Not authorized to perform operation"):
+		return GLib.Error.new_literal(Polkit.error_quark(), message, Polkit.Error.NOT_AUTHORIZED)
+
+	def __init__(self, action_id, details=None, flags=Polkit.CheckAuthorizationFlags.ALLOW_USER_INTERACTION):
+		if callable(action_id):
+			raise TypeError("PolkitAuthorization needs an action id")
+		self.action_id = action_id
+		self.details = details
+		self.flags = flags
+
+	def __call__(self, func):
+		# check, if func needs the dbus_bus and dbus_method_invokation kw args
+		try:
+			method_args = inspect.getargspec(func)[0]
+		except TypeError:
+			# not a function
+			method_args = ()
+		is_async = getattr(func, "async", None)
+		needs_dbus_method_invocation = ("dbus_method_invocation" in method_args or
+										getattr(func, "arg_dbus_method_invocation", None) or
+										is_async)
+		needs_dbus_bus = ("dbus_bus" in method_args or getattr(func, "arg_dbus_bus", None))
+		needs_polkit_is_authorized = ("polkit_is_authorized" in method_args or getattr(func, "arg_polkit_is_authorized", None))
+
+		@functools.wraps(func)
+		def wrapper(*args, **kw):
+			bus = kw['dbus_bus'] if needs_dbus_bus else kw.pop('dbus_bus')
+			method_invocation = kw['dbus_method_invocation'] if needs_dbus_method_invocation else kw.pop('dbus_method_invocation')
+			try:
+				cancellable = Gio.Cancellable()
+				state = dict(bus=bus,
+							method_invocation=method_invocation,
+							func=func,
+							is_async=is_async,
+							needs_polkit_is_authorized=needs_polkit_is_authorized,
+							cancellable=cancellable,
+							args=args,
+							kw=kw)
+				timeout = bus.timeout
+				if timeout == -1:
+					# -1 indicates a default value
+					timeout = 25000  # DBus default
+
+				GLib.timeout_add(timeout, cancellable.cancel)
+				Polkit.Authority.get_async(cancellable, self._cb_get_authority_ready, state)
+			except Exception as e:
+				traceback.print_exc()  # FIXME: better error reporting. logging?
+				method_invocation.return_exception(e)
+
+		wrapper.async = True
+		wrapper.arg_dbus_bus = True
+		wrapper.arg_dbus_method_invocation = True
+		return wrapper
+
+	def _cb_get_authority_ready(self, source_object, res, state):
+		# source_object is None
+		method_invocation = state['method_invocation']
+		try:
+			authority = Polkit.Authority.get_finish(res)
+			assert authority is not None
+
+			sender = method_invocation.get_sender()
+			dbus_service = state['bus'].get('.DBus')['']
+			sender_pid = dbus_service.GetConnectionUnixProcessID(sender)  # synchronous call for now
+			subject = Polkit.UnixProcess.new(sender_pid)
+
+			authority.check_authorization(subject,
+										self.action_id,
+										self.details,
+										self.flags,
+										state['cancellable'],
+										self._cb_check_authorization_ready,
+										state)
+		except Exception as e:
+			traceback.print_exc()  # FIXME: better error reporting. logging?
+			method_invocation.return_exception(e)
+
+	def _cb_check_authorization_ready(self, authority, res, state):
+		method_invocation = state['method_invocation']
+		needs_polkit_is_authorized = state['needs_polkit_is_authorized']
+		try:
+			result = authority.check_authorization_finish(res)
+			is_authorized = result.get_is_authorized()
+			if not needs_polkit_is_authorized and not is_authorized:
+				method_invocation.return_exception(self.NotAuthorizedError())
+				return
+
+			if needs_polkit_is_authorized:
+				state['kw']['polkit_is_authorized'] = is_authorized
+
+			result = state['func'](*state['args'], **state['kw'])
+			if not (state['is_async'] or result is registration.METHOD_IS_ASYNC):
+				method_invocation.return_value(result)
+
+		except Exception as e:
+			traceback.print_exc()  # FIXME: better error reporting. logging?
+			method_invocation.return_exception(e)

--- a/pydbus/authorization.py
+++ b/pydbus/authorization.py
@@ -23,7 +23,8 @@ A decorator for Polkit authorization
 """
 
 from __future__ import print_function, absolute_import
-
+import gi
+gi.require_version('Polkit', '1.0')
 from gi.repository import GLib, Polkit, Gio
 import functools
 from pydbus import registration, generic

--- a/pydbus/bus.py
+++ b/pydbus/bus.py
@@ -18,11 +18,11 @@ class Bus(ProxyMixin, OwnMixin, WatchMixin, SubscriptionMixin, RegistrationMixin
 	def __exit__(self, exc_type, exc_value, traceback):
 		self.con = None
 
-def SystemBus():
-	return Bus(Bus.Type.SYSTEM)
+def SystemBus(timeout=1000):
+	return Bus(Bus.Type.SYSTEM, timeout=timeout)
 
-def SessionBus():
-	return Bus(Bus.Type.SESSION)
+def SessionBus(timeout=1000):
+	return Bus(Bus.Type.SESSION, timeout=timeout)
 
 if __name__ == "__main__":
 	import sys

--- a/pydbus/tests/publish_async.py
+++ b/pydbus/tests/publish_async.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Anselm Kruis
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+
+"""
+A variant of publish, that works asynchronously and authorizes the service using Polkit
+"""
+
+
+from __future__ import print_function, absolute_import
+from pydbus import SessionBus
+from pydbus.authorization import PolkitAuthorization
+from gi.repository import GObject, GLib, Polkit, Gio
+from threading import Thread
+import sys
+import traceback
+
+dot_count = 0
+done = 0
+loop = GObject.MainLoop()
+
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lvht.Foo1'>
+			<method name='HelloWorld1'>
+					<arg type='s' name='a' direction='in'/>
+					<arg type='i' name='b' direction='in'/>
+					<arg type='s' name='response' direction='out'/>
+			</method>
+			<method name='HelloWorld2'>
+					<arg type='s' name='a' direction='in'/>
+					<arg type='i' name='b' direction='in'/>
+					<arg type='s' name='response' direction='out'/>
+			</method>
+	</interface>
+</node>
+	'''
+
+	def __init__(self, id):
+		self.id = id
+
+	def do_cancel(self, cancellable):
+		print("Timeout, canceling operation")
+		sys.stdout.flush()
+		cancellable.cancel()
+
+	# the simple way
+	@PolkitAuthorization("org.freedesktop.policykit.exec")
+	def HelloWorld1(self, a, b, polkit_is_authorized):
+		global done
+		done += 1
+		if done == 2:
+			GLib.idle_add(loop.quit)
+		if not polkit_is_authorized:
+			raise PolkitAuthorization.NotAuthorizedError("You are not authorized!")
+		res = self.id + ": " + a + str(b)
+		print(res)
+		return res
+
+	# use the low level API, otherwise the same as HelloWorld1
+	def HelloWorld2(self, a, b, dbus_method_invocation, dbus_bus):
+		try:
+			cancellable = Gio.Cancellable()
+			state = dict(a=a,
+						b=b,
+						method_invocation=dbus_method_invocation,
+						bus=dbus_bus,
+						cancellable=cancellable)
+			GLib.timeout_add(dbus_bus.timeout, self.do_cancel, cancellable)
+			Polkit.Authority.get_async(cancellable, self._cb_get_authority_ready, state)
+		except Exception as e:
+			traceback.print_exc()
+			dbus_method_invocation.return_exception(e)
+	HelloWorld2.async = True
+
+	def _cb_get_authority_ready(self, source_object, res, state):
+		# source_object is None
+		dbus_bus = state['bus']
+		dbus_method_invocation = state['method_invocation']
+		cancellable = state['cancellable']
+
+		try:
+			authority = Polkit.Authority.get_finish(res)
+			assert authority is not None
+
+			sender = dbus_method_invocation.get_sender()
+			dbus_service = dbus_bus.get('.DBus')['']
+			sender_pid = dbus_service.GetConnectionUnixProcessID(sender)  # synchronous call for now
+			state['sender_pid'] = sender_pid
+			subject = Polkit.UnixProcess.new(sender_pid)
+
+			authority.check_authorization(subject,
+										"org.freedesktop.policykit.exec",  # uses auth_admin
+										None,
+										Polkit.CheckAuthorizationFlags.ALLOW_USER_INTERACTION,
+										cancellable,
+										self._cb_check_authorization_ready,
+										state)
+		except Exception as e:
+			traceback.print_exc()
+			dbus_method_invocation.return_exception(e)
+
+	def _cb_check_authorization_ready(self, authority, res, state):
+		dbus_method_invocation = state['method_invocation']
+		a = state['a']
+		b = state['b']
+		sender_pid = state['sender_pid']
+		try:
+			global done
+			done += 1
+			if done == 2:
+				GLib.idle_add(loop.quit)
+
+			result = authority.check_authorization_finish(res)
+			if not result.get_is_authorized():
+				dbus_method_invocation.return_dbus_error("unknown.PermissionDenied", "You are not authorized!")
+				return
+
+			res = self.id + ": " + a + str(b) + " sender pid " + str(sender_pid)
+			print(res)
+			dbus_method_invocation.return_value(res)
+
+		except Exception as e:
+			traceback.print_exc()
+			dbus_method_invocation.return_exception(e)
+
+
+def print_dots():
+	"""Print one dot per second, if the mainloop is running"""
+	global dot_count
+	print(".", end='')
+	dot_count += 1
+	if dot_count >= 80:
+		print("")
+		dot_count = 0
+	sys.stdout.flush()
+	return True
+
+with SessionBus(timeout=30 * 1000) as bus:
+	with bus.publish("net.lew21.pydbus.Test", TestObject("Main"), ("Lol", TestObject("Lol"))):
+		remoteMain = bus.get("net.lew21.pydbus.Test")
+		remoteLol = bus.get("net.lew21.pydbus.Test", "Lol")
+
+		def t1_func():
+			print(remoteMain.HelloWorld1("t", 1))
+
+		def t2_func():
+			print(remoteLol.HelloWorld2("t", 2))
+
+		t1 = Thread(None, t1_func)
+		t2 = Thread(None, t2_func)
+		t1.daemon = True
+		t2.daemon = True
+
+		t1.start()
+		t2.start()
+
+		GLib.timeout_add_seconds(1, print_dots)
+
+		loop.run()
+
+		t1.join()
+		t2.join()


### PR DESCRIPTION
Hi Janusz,

first of all many thanks for pydbus. It makes DBus programming really simple.
I'm currently preparing a little project, that contains an SystemBus service. One
method call needs polkit authorization. Now, if polkit performs a user interaction, the authorization takes a lot of time. Therefore I need to use asynchronous functions.

This pull request contains two changes and one addition:
1. Addition of a timeout argument to SystemBus() and SessionBus(). Trivial.
2. Enhancement of registration.ObjectWrapper.call_method(). call_method now inspects the called method to determine, if it wants the bus and/or the method_invocation as additional arguments and if the called method returns a value synchronously or asynchronously. The new file tests/publish_async.py contains an example.
3. The new file authorization.py provides a function/method decorator, that uses Polkit to authorize the call of the wrapped function. Of course this decorator works fully asynchronously and does not block the main loop.

Of course this pull request is not ready: it lacks documentation. But I would like to get you opinion, before I start writing extensive documentation.

Regards,
   Anselm

p.s. I'll be on holiday now for a few days