### PR TITLE
Use pytest

### DIFF
--- a/pydbus/tests/context.py
+++ b/pydbus/tests/context.py
@@ -1,39 +1,40 @@
 from pydbus import SessionBus, connect
 import os
 
-DBUS_SESSION_BUS_ADDRESS = os.getenv("DBUS_SESSION_BUS_ADDRESS")
+import pytest
 
-with connect(DBUS_SESSION_BUS_ADDRESS) as bus:
-	bus.dbus
 
-del bus._dbus
-try:
-	bus.dbus
-	assert(False)
-except RuntimeError:
-	pass
+def test_remove_dbus():
+	DBUS_SESSION_BUS_ADDRESS = os.getenv("DBUS_SESSION_BUS_ADDRESS")
 
-with SessionBus() as bus:
-	pass
+	with connect(DBUS_SESSION_BUS_ADDRESS) as bus:
+		bus.dbus
 
-# SessionBus() and SystemBus() are not closed automatically, so this should work:
-bus.dbus
+	del bus._dbus
+	with pytest.raises(RuntimeError):
+		bus.dbus
 
-with bus.request_name("net.lew21.Test"):
-	pass
 
-with bus.request_name("net.lew21.Test"):
-	pass
-
-with bus.request_name("net.lew21.Test"):
-	try:
-		bus.request_name("net.lew21.Test")
-		assert(False)
-	except RuntimeError:
+def test_use_exited_bus():
+	"""Test using a bus instance after its context manager."""
+	with SessionBus() as bus:
 		pass
 
-with bus.watch_name("net.lew21.Test"):
-	pass
+	# SessionBus() and SystemBus() are not closed automatically, so this should work:
+	bus.dbus
 
-with bus.subscribe(sender="net.lew21.Test"):
-	pass
+	with bus.request_name("net.lew21.Test"):
+		pass
+
+	with bus.request_name("net.lew21.Test"):
+		pass
+
+	with bus.request_name("net.lew21.Test"):
+		with pytest.raises(RuntimeError):
+			bus.request_name("net.lew21.Test")
+
+	with bus.watch_name("net.lew21.Test"):
+		pass
+
+	with bus.subscribe(sender="net.lew21.Test"):
+		pass

--- a/pydbus/tests/identifier.py
+++ b/pydbus/tests/identifier.py
@@ -1,19 +1,13 @@
-from __future__ import print_function
-from pydbus.identifier import filter_identifier
-import sys
+import pytest
 
-tests = [
+from pydbus.identifier import filter_identifier
+
+@pytest.mark.parametrize("input, output", [
 	("abc", "abc"),
 	("a_bC", "a_bC"),
 	("a-b_c", "a_b_c"),
 	("a@bc", "abc"),
 	("!@#$%^&*", ""),
-]
-
-ret = 0
-for input, output in tests:
-	if not filter_identifier(input) == output:
-		print("ERROR: filter(" + input + ") returned: " + filter_identifier(input), file=sys.stderr)
-		ret = 1
-
-sys.exit(ret)
+])
+def test_filter_identifier(input, output):
+	assert filter_identifier(input) == output

--- a/pydbus/tests/util.py
+++ b/pydbus/tests/util.py
@@ -1,0 +1,113 @@
+import time
+
+from threading import Thread, Lock
+
+
+class TimeLock(object):
+
+	"""Lock which can timeout."""
+
+	def __init__(self):
+		self._lock = Lock()
+
+	def acquire(self, blocking=True, timeout=-1):
+		if timeout < 0:
+			return self._lock.acquire(blocking)
+
+		end_time = time.time() + timeout
+		while time.time() < end_time:
+			if self._lock.acquire(False):
+				return True
+			else:
+				time.sleep(0.001)
+		return False
+
+	def release(self):
+		return self._lock.release()
+
+	def __enter__(self):
+		self.acquire()
+
+	def __exit__(self, exc_type, exc_val, exc_tb):
+		self.release()
+
+
+class ClientPool(object):
+
+	"""A pool of threads, which determines if every thread finished."""
+
+	def __init__(self, finisher):
+		self._threads = set()
+		self._finisher = finisher
+		self._lock = Lock()
+
+	def add(self, thread):
+		if thread in self._threads:
+			raise ValueError('Thread was already added')
+		self._threads.add(thread)
+
+	def finish(self, thread):
+		with self._lock:
+			self._threads.remove(thread)
+			finished = not self._threads
+
+		if finished:
+			self._finisher()
+
+
+class ClientThread(Thread):
+
+	"""
+	Thread subclass which is also handling the main loop.
+
+	Each thread can be a part of a pool. If every thread of the pool has
+	finished, it'll execute some finishing action (usually to quit the loop).
+	If no pool is defined, it'll make the thread part of it's own pool.
+
+	The return value of the function is saved as the result. If the function
+	raised an `AssertionError` it'll save that exception. In any case it'll
+	tell the pool that it finished.
+	"""
+
+	def __init__(self, func, loop, pool=None):
+		super(ClientThread, self).__init__(None)
+		self.daemon = True
+		self.loop = loop
+		self.func = func
+		self._lock = TimeLock()
+		self._result = None
+		if pool is None:
+			pool = ClientPool(loop.quit)
+		self._pool = pool
+		if pool is not False:
+			self._pool.add(self)
+
+	def run(self):
+		with self._lock:
+			while not self.loop.is_running:
+				pass
+			try:
+				self._result = self.func()
+			except AssertionError as e:
+				self._result = e
+			finally:
+				if self._pool is not False:
+					self._pool.finish(self)
+
+	@property
+	def result(self):
+		# If the thread itself quit the loop, it might not have released the
+		# lock before the main thread already continues to get the result. So
+		# wait for a bit to actually let the thread finish.
+		if self._lock.acquire(timeout=0.1):
+			try:
+				if isinstance(self._result, AssertionError):
+					# This will say the error happened here, even though it
+					# happened inside the thread.
+					raise self._result
+				else:
+					return self._result
+			finally:
+				self._lock.release()
+		else:
+			raise ValueError()

--- a/tests/py2.7-ubuntu-14.04.dockerfile
+++ b/tests/py2.7-ubuntu-14.04.dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y dbus python-gi python-pip psmisc python-dev
 RUN python2 --version
-RUN pip2 install greenlet
+RUN pip2 install greenlet pytest
 
 ADD . /root/
 RUN cd /root && python2 setup.py install

--- a/tests/py2.7-ubuntu-16.04.dockerfile
+++ b/tests/py2.7-ubuntu-16.04.dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y dbus python-gi python-pip psmisc
 RUN python2 --version
-RUN pip2 install greenlet
+RUN pip2 install greenlet pytest
 
 ADD . /root/
 RUN cd /root && python2 setup.py install

--- a/tests/py3.4-ubuntu-14.04.dockerfile
+++ b/tests/py3.4-ubuntu-14.04.dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y dbus python3-gi python3-pip psmisc python3-dev
 RUN python3 --version
-RUN pip3 install greenlet
+RUN pip3 install greenlet pytest
 
 ADD . /root/
 RUN cd /root && python3 setup.py install

--- a/tests/py3.5-ubuntu-16.04.dockerfile
+++ b/tests/py3.5-ubuntu-16.04.dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update
 
 RUN apt-get install -y dbus python3-gi python3-pip psmisc
 RUN python3 --version
-RUN pip3 install greenlet
+RUN pip3 install greenlet pytest
 
 ADD . /root/
 RUN cd /root && python3 setup.py install

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+cd "$(dirname "$(dirname "$0")")"
+
 ADDRESS_FILE=$(mktemp /tmp/pydbustest.XXXXXXXXX)
 PID_FILE=$(mktemp /tmp/pydbustest.XXXXXXXXX)
 
@@ -15,8 +17,7 @@ rm "$ADDRESS_FILE" "$PID_FILE"
 
 PYTHON=${1:-python}
 
-"$PYTHON" -m pydbus.tests.context
-"$PYTHON" -m pydbus.tests.identifier
+"$PYTHON" -m pytest -v pydbus/tests/identifier.py pydbus/tests/context.py
 if [ "$2" != "dontpublish" ]
 then
 	"$PYTHON" -m pydbus.tests.publish

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -17,10 +17,9 @@ rm "$ADDRESS_FILE" "$PID_FILE"
 
 PYTHON=${1:-python}
 
-"$PYTHON" -m pytest -v pydbus/tests/identifier.py pydbus/tests/context.py
+FILES="pydbus/tests/identifier.py pydbus/tests/context.py"
 if [ "$2" != "dontpublish" ]
 then
-	"$PYTHON" -m pydbus.tests.publish
-	"$PYTHON" -m pydbus.tests.publish_properties
-	"$PYTHON" -m pydbus.tests.publish_multiface
+	FILES="$FILES pydbus/tests/publish.py pydbus/tests/publish_properties.py pydbus/tests/publish_multiface.py"
 fi
+"$PYTHON" -m pytest -v $FILES


### PR DESCRIPTION
This rewrites the existing tests to be used with `pytest` which produces a more helpful output when an assertion failed. It also allows to have multiple separate tests in one file but separated in functions.

It also adds some tests when using multiple interfaces in one class and it checks if the results are actually valid instead of just printing them out.