### PR TITLE
Append more information to kwargs for dbus method callback

### DIFF
--- a/pydbus/registration.py
+++ b/pydbus/registration.py
@@ -74,11 +74,14 @@ class ObjectWrapper(ExitableWithAliases("unwrap")):
 
 			sig = signature(method)
 
-			kwargs = {}
+			kwargs = {"sender": sender, "object_path": object_path, "interface_name": interface_name}
 			if "dbus_context" in sig.parameters and sig.parameters["dbus_context"].kind in (Parameter.POSITIONAL_OR_KEYWORD, Parameter.KEYWORD_ONLY):
 				kwargs["dbus_context"] = MethodCallContext(invocation)
 
-			result = method(*parameters, **kwargs)
+			try:
+				result = method(*parameters, **kwargs)
+			except TypeError:
+				result = method(*parameters)
 
 			if len(outargs) == 0:
 				invocation.return_value(None)


### PR DESCRIPTION
This can be usefull to determine, e.g., the caller pid or uid within a dbus method callback.
In addition use try except block for the actual method call such that the kwargs argument is optional. 