### PR TITLE
Include copyright notice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,18 @@ The Tutorial_ contains more examples and docs.
 Copyright Information
 ---------------------
 
+Copyright (C) 2014, 2015, 2016 Linus Lewandowski <linus@lew21.net>
+
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
 License as published by the Free Software Foundation; either
 version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA


### PR DESCRIPTION
Although it clearly declares it license as LGPL 2.1, pydbus does not include any notice telling who the copyright holder is (apart for the one in the tutorial).
This patch adds that information to README.rst.
Keep in mind that GNU recommends placing this information in the headers of every source file, but this patch does not follow that recommendation.
Also notice that I have not included any reference to other authors (as the ones in https://github.com/LEW21/pydbus/commit/b8e91b2fb77f4d76cafa51a23b259ce1020d1e75 or https://github.com/LEW21/pydbus/commit/bd10e17963695aa96d8328c059ed65557afce17f  commits).