### PR TITLE
Refactor tests runner script to use dbus-launch instead of dbus-daemon

### DIFF
--- a/tests/py2.7-ubuntu-14.04.dockerfile
+++ b/tests/py2.7-ubuntu-14.04.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 RUN apt-get update
 
-RUN apt-get install -y dbus python-gi python-pip psmisc python-dev
+RUN apt-get install -y dbus python-gi python-pip psmisc python-dev dbus-x11
 RUN python2 --version
 RUN pip2 install greenlet
 

--- a/tests/py2.7-ubuntu-16.04.dockerfile
+++ b/tests/py2.7-ubuntu-16.04.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 RUN apt-get update
 
-RUN apt-get install -y dbus python-gi python-pip psmisc
+RUN apt-get install -y dbus python-gi python-pip psmisc dbus-x11
 RUN python2 --version
 RUN pip2 install greenlet
 

--- a/tests/py3.4-ubuntu-14.04.dockerfile
+++ b/tests/py3.4-ubuntu-14.04.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 RUN apt-get update
 
-RUN apt-get install -y dbus python3-gi python3-pip psmisc python3-dev
+RUN apt-get install -y dbus python3-gi python3-pip psmisc python3-dev dbus-x11
 RUN python3 --version
 RUN pip3 install greenlet
 

--- a/tests/py3.5-ubuntu-16.04.dockerfile
+++ b/tests/py3.5-ubuntu-16.04.dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 RUN apt-get update
 
-RUN apt-get install -y dbus python3-gi python3-pip psmisc
+RUN apt-get install -y dbus python3-gi python3-pip psmisc dbus-x11
 RUN python3 --version
 RUN pip3 install greenlet
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,17 +1,9 @@
 #!/bin/sh
 set -e
 
-ADDRESS_FILE=$(mktemp /tmp/pydbustest.XXXXXXXXX)
-PID_FILE=$(mktemp /tmp/pydbustest.XXXXXXXXX)
+eval `dbus-launch --sh-syntax`
 
-dbus-daemon --session --print-address=0 --print-pid=1 --fork 0>"$ADDRESS_FILE" 1>"$PID_FILE"
-
-export DBUS_SESSION_BUS_ADDRESS=$(cat "$ADDRESS_FILE")
-PID=$(cat "$PID_FILE")
-
-trap 'kill -TERM $PID' EXIT
-
-rm "$ADDRESS_FILE" "$PID_FILE"
+trap 'kill -TERM $DBUS_SESSION_BUS_PID' EXIT
 
 PYTHON=${1:-python}
 


### PR DESCRIPTION
This PR refactors tests/run.sh to use dbus-launch instead of dbus-daemon.

dbus-launch is more suited to this task and leads to a cleaner script. Also for some reason descriptor 0 redirection to a file was not working on some systems that I have tested it on.

I know there is an [ongoing effort to migrate to pytest](https://github.com/LEW21/pydbus/pull/30) but this fixes run.sh in the meantime.

Considering that at this moment the tests are independent from each other, dbus-run-session could be used instead to have each test launch its own dbus session (and to get it finished automatically at the end of the test), but I have kept the original approach of a common dbus session for all the tests.