### PR TITLE
Fix typo in section title formatting in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ List systemd units
 	    print(unit)
 
 Start or stop systemd unit
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code-block:: python
 
 	from pydbus import SystemBus


### PR DESCRIPTION
Fix typo in README.rst formatting in the underline of "Start or stop systemd unit" title.
rst2html is complaining about it:
README.rst:49: (WARNING/2) Title underline too short.