### PR TITLE
make direction attribute conforming to introspect.dtd

### DIFF
--- a/pydbus/proxy_method.py
+++ b/pydbus/proxy_method.py
@@ -33,8 +33,8 @@ class ProxyMethod(object):
 		self.__name__ = method.attrib["name"]
 		self.__qualname__ = self._iface_name + "." + self.__name__
 
-		self._inargs  = [(arg.attrib.get("name", ""), arg.attrib["type"]) for arg in method if arg.tag == "arg" and arg.attrib["direction"] == "in"]
-		self._outargs = [arg.attrib["type"] for arg in method if arg.tag == "arg" and arg.attrib["direction"] == "out"]
+		self._inargs  = [(arg.attrib.get("name", ""), arg.attrib["type"]) for arg in method if arg.tag == "arg" and arg.attrib.get("direction", "in") == "in"]
+		self._outargs = [arg.attrib["type"] for arg in method if arg.tag == "arg" and arg.attrib.get("direction", "in") == "out"]
 		self._sinargs  = "(" + "".join(x[1] for x in self._inargs) + ")"
 		self._soutargs = "(" + "".join(self._outargs) + ")"
 


### PR DESCRIPTION
direction attribute defaults to "in" as
in the DTD(*1), direction attribute is defined as following:

```
<!ATTRLIST arg direction (in|out) "in">
```

*1) http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd