### PR TITLE
Support asynchronous calls (#58)

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -84,7 +84,8 @@ All objects have methods, properties and signals.
 Setting up an event loop
 ========================
 
-To handle signals emitted by exported objects, or to export your own objects, you need to setup an event loop.
+To handle signals emitted by exported objects, to asynchronously call methods
+or to export your own objects, you need to setup an event loop.
 
 The only main loop supported by ``pydbus`` is GLib.MainLoop.
 
@@ -155,6 +156,14 @@ To see the API of a specific proxy object, use help()::
 To call a method::
 
     dev.Disconnect()
+
+To asynchronously call a method::
+
+    def print_result(returned=None, error=None):
+        print(returned, error)
+
+    dev.GetAppliedConnection(0, callback=print_result)
+    loop.run()
 
 To read a property::
 

--- a/tests/publish_async.py
+++ b/tests/publish_async.py
@@ -1,0 +1,63 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+
+done = 0
+loop = GLib.MainLoop()
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lew21.pydbus.tests.publish_async'>
+		<method name='HelloWorld'>
+			<arg type='i' name='x' direction='in'/>
+			<arg type='s' name='response' direction='out'/>
+		</method>
+	</interface>
+</node>
+	'''
+	def __init__(self, id):
+		self.id = id
+
+	def HelloWorld(self, x):
+		res = self.id + ": " + str(x)
+		print(res)
+		return res
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.tests.publish_async", TestObject("Obj")):
+	remote = bus.get("net.lew21.pydbus.tests.publish_async")
+
+	def callback(x, returned=None, error=None):
+		print("asyn: " + returned)
+		assert (returned is not None)
+		assert(error is None)
+		assert(x == int(returned.split()[1]))
+
+		global done
+		done += 1
+		if done == 3:
+			loop.quit()
+
+	def t1_func():
+		remote.HelloWorld(1, callback=callback, callback_args=(1,))
+		remote.HelloWorld(2, callback=callback, callback_args=(2,))
+		print("sync: " + remote.HelloWorld(3))
+		remote.HelloWorld(4, callback=callback, callback_args=(4,))
+
+	t1 = Thread(None, t1_func)
+	t1.daemon = True
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	t1.start()
+
+	loop.run()
+
+	t1.join()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/publish_async.py
 fi


### PR DESCRIPTION
Added support for asynchronous calls of methods. A method is called
synchronously unless its callback parameter is specified. A callback
is a function f(*args, returned=None, error=None), where args is
callback_args specified in the method call, returned is a return
value of the method and error is an exception raised by the method.

Example of an asynchronous call:
```
def func(x, y, returned=None, error=None):
  pass

proxy.Method(a, b, callback=func, callback_args=(x, y))
```