### PR TITLE
Introduce DBusException for propagating DBusErrors

### DIFF
--- a/pydbus/__init__.py
+++ b/pydbus/__init__.py
@@ -1,4 +1,5 @@
 from .bus import SystemBus, SessionBus, connect
+from .exceptions import DBusException
 from gi.repository.GLib import Variant
 
-__all__ = ["SystemBus", "SessionBus", "connect", "Variant"]
+__all__ = ["SystemBus", "SessionBus", "connect", "DBusException", "Variant"]

--- a/pydbus/exceptions.py
+++ b/pydbus/exceptions.py
@@ -1,0 +1,3 @@
+class DBusException(Exception):
+	dbus_name = 'org.freedesktop.DBus.Error.Failed'
+	silent = False

--- a/tests/dbus_exception.py
+++ b/tests/dbus_exception.py
@@ -1,0 +1,77 @@
+from pydbus import SessionBus, DBusException
+from gi.repository import GLib
+from threading import Thread
+import sys
+
+done = 0
+loop = GLib.MainLoop()
+
+class CustomDBusException(DBusException):
+	dbus_name = "net.lew21.pydbus.Test.Error.Custom"
+	silent = True
+
+class TestObject(object):
+	'''
+<node>
+	<interface name='net.lvht.ExceptionTest'>
+		<method name='QuitService'>
+		</method>
+		<method name='RaiseException'>
+		</method>
+		<method name='RaiseDBusException'>
+		</method>
+	</interface>
+</node>
+	'''
+	def __init__(self, id):
+		self.id = id
+
+	def QuitService(self):
+		loop.quit()
+		return None
+
+	def RaiseException(self):
+		raise Exception("sensitive")
+		return None
+
+	def RaiseDBusException(self):
+		raise CustomDBusException("insensitive")
+		return None
+
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.Test", TestObject("Main")):
+	remoteMain = bus.get("net.lew21.pydbus.Test")
+
+	def t1_func():
+		try:
+			remoteMain.RaiseDBusException()
+		except Exception as e:
+			if 'insensitive' not in str(e):
+				raise e
+			if CustomDBusException.dbus_name not in str(e):
+				raise e
+		try:
+			remoteMain.RaiseException()
+		except Exception as e:
+			if 'sensitive' in str(e):
+				raise e
+			if DBusException.dbus_name not in str(e):
+				raise e
+		remoteMain.QuitService()
+
+	t1 = Thread(None, t1_func)
+	t1.daemon = True
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	t1.start()
+
+	loop.run()
+
+	t1.join()

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/dbus_exception.py
 fi


### PR DESCRIPTION
DBusException can be subclassed, to indicate exceptions, that are meant to
be translated to DBusErrors.
The type of error is encoded by the class variable 'dbus_name'.
The class variable 'silent' can be used to suppress logging.