### PR TITLE
Python2 compatibility: use object to query for it's doc 

### DIFF
--- a/pydbus/registration.py
+++ b/pydbus/registration.py
@@ -144,7 +144,7 @@ class RegistrationMixin:
 			try:
 				node_info = type(object).dbus
 			except AttributeError:
-				node_info = type(object).__doc__
+				node_info = object.__doc__
 
 		if type(node_info) != list and type(node_info) != tuple:
 			node_info = [node_info]

--- a/tests/publish_classdocstring.py
+++ b/tests/publish_classdocstring.py
@@ -1,0 +1,44 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+from time import sleep
+
+loop = GLib.MainLoop()
+
+class TestObject:
+	'''
+<node>
+	<interface name='net.lew21.pydbus.tests.Iface1'>
+		<method name='Method1'>
+			<arg type='s' name='response' direction='out'/>
+		</method>
+	</interface>
+</node>
+	'''
+	def Method1(self):
+		sleep(1)
+		loop.quit()
+		return "Passed!"
+
+bus = SessionBus()
+
+with bus.publish("net.lew21.pydbus.tests.publish_classdocstring", TestObject()):
+	remote = bus.get("net.lew21.pydbus.tests.publish_classdocstring")
+
+	def closer():
+		print(remote.Method1())
+
+	t1 = Thread(None, closer)
+
+	def handle_timeout():
+		print("ERROR: Timeout.")
+		sys.exit(1)
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	t1.start()
+
+	loop.run()
+
+	t1.join()


### PR DESCRIPTION
Previously Python2 `type(object)` returned `instance` instead of actual class. `instance`'s `__doc__` is:
```
instance(class[, dict])

Create an instance without calling its __init__() method.
The class must be a classic class.\nIf present, dict must be a dictionary or None.
```

Shortly checked on python3.6 and it seems to run as well.

Will add a test later for this functionality later on.

Fix #70 