### PR TITLE
Fix for Issue #69, Methods returning non-trivial types fail

### DIFF
--- a/pydbus/proxy_method.py.bak
+++ b/pydbus/proxy_method.py.bak
@@ -36,10 +36,7 @@ class ProxyMethod(object):
 		self._inargs  = [(arg.attrib.get("name", ""), arg.attrib["type"]) for arg in method if arg.tag == "arg" and arg.attrib.get("direction", "in") == "in"]
 		self._outargs = [arg.attrib["type"] for arg in method if arg.tag == "arg" and arg.attrib.get("direction", "in") == "out"]
 		self._sinargs  = "(" + "".join(x[1] for x in self._inargs) + ")"
-		self._soutargs = "".join(self._outargs)
-		self._ret_obj = len(self._outargs) == 1 and self._outargs[0].startswith("(")
-		if not self._ret_obj:
-			self._soutargs = "(" + self._soutargs + ")"
+		self._soutargs = "(" + "".join(self._outargs).strip("()") + ")"
 
 		self_param = Parameter("self", Parameter.POSITIONAL_ONLY)
 		pos_params = []
@@ -79,7 +76,7 @@ class ProxyMethod(object):
 
 		if len(self._outargs) == 0:
 			return None
-		elif len(self._outargs) == 1 and not self._ret_obj:
+		elif len(self._outargs) == 1:
 			return ret[0]
 		else:
 			return ret


### PR DESCRIPTION
`ProxyMethod.__call__()` does not correctly handle the case of a proxied method that returns a single dbus object. That is, a method that returns a value with a dbus signature of the form `"(xyz)"`.

I found two problems. The first is in the code that builds the proxied method's return type's signature.

Consider the case of a proxied method with `self._outargs = ["(dsii)"]`.
To build `self._soutargs`, `ProxyMethod.__init__()` unconditionally adds enclosing parentheses:

    self._soutargs = "(" + "".join(self._outargs) + ")"

This will result in an error being returned from `instance._bus.con.call_sync()` when called from `ProxyMethod.__call__()`:

    gi._glib.GError: Method 'GetOrientation' returned type '(dsii)', but expected '((dsii))'

The second problem is in ProxyMethod.__call__(), in handling the value returned by call_sync(), which is a tuple, assigned to the variable `ret`:

    if len(self._outargs) == 0:
        return None
    elif len(self._outargs) == 1:
        return ret[0]
    else:
        return ret

If the proxied method returns a single object, `len(self._outargs)` will be 1, and only the first element of the tuple will be returned from `ProxyMethod.__call__()`.

To handle this particular case, I added a state variable `self._ret_obj`, which `ProxyMethod.__init__()` sets to `True` iff `len(self._outargs) == 1` and `self._outargs[0]` starts with "(". In other words, if this flag is set, the proxied function will return a single argument, which will be a dbus object.

    self._ret_obj = len(self._outargs) == 1 and self._outargs[0].startswith("(")

It then tests `self._ret_obj` and adds enclosing parentheses if it is `False`.

`ProxyMethod.__call__()` tests `self._ret_obj` when deciding whether to return the entire tuple or only the first element:

    if len(self._outargs) == 0:
        return None
    elif len(self._outargs) == 1 and not self._ret_obj:
        return ret[0]
    else:
        return ret
