### PR TITLE
Support for passing and receiving Unix file descriptors

### DIFF
--- a/pydbus/unixfd.py
+++ b/pydbus/unixfd.py
@@ -1,0 +1,53 @@
+from gi.repository import Gio
+
+# signature type code
+TYPE_FD = "h"
+
+def is_supported(conn):
+	"""
+	Check if the message bus supports passing of Unix file descriptors.
+	"""
+	return conn.get_capabilities() & Gio.DBusCapabilityFlags.UNIX_FD_PASSING
+
+
+def extract(params, signature, fd_list):
+	"""
+	Extract any file descriptors from a UnixFDList (e.g. after
+	receiving from D-Bus) to a parameter list.
+	Receiver must call os.dup on any fd it decides to keep/use.
+	"""
+	if not fd_list:
+		return params
+	return [fd_list.get(0)
+		if arg == TYPE_FD
+		else val
+		for val, arg
+		in zip(params, signature)]
+
+
+def make_fd_list(params, signature, steal=False):
+	"""
+	Embed any unix file descriptors in a parameter list into a
+	UnixFDList (for D-Bus-dispatch).
+	If steal is true, the responsibility for closing the file
+	descriptors are transferred to the UnixFDList object.
+	If steal is false, the file descriptors will be duplicated
+	and the caller must close the original file descriptors.
+	"""
+	if not any(arg
+		   for arg in signature
+		   if arg == TYPE_FD):
+		return None
+
+	fds = [param
+	       for param, arg
+	       in zip(params, signature)
+	       if arg == TYPE_FD]
+
+	if steal:
+		return Gio.UnixFDList.new_from_array(fds)
+
+	fd_list = Gio.UnixFDList()
+	for fd in fds:
+		fd_list.append(fd)
+	return fd_list

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -15,4 +15,5 @@ then
 	"$PYTHON" $TESTS_DIR/publish.py
 	"$PYTHON" $TESTS_DIR/publish_properties.py
 	"$PYTHON" $TESTS_DIR/publish_multiface.py
+	"$PYTHON" $TESTS_DIR/unixfd.py
 fi

--- a/tests/unixfd.py
+++ b/tests/unixfd.py
@@ -1,0 +1,60 @@
+from pydbus import SessionBus
+from gi.repository import GLib
+from threading import Thread
+import sys
+import os
+
+loop = GLib.MainLoop()
+
+
+with open(__file__) as f:
+	contents = f.read()
+
+
+class TestObject(object):
+	"""
+	<node>
+	<interface name="baz.bar.Foo">
+		<method name="Hello">
+			<arg type="h" name="in_fd" direction="in"/>
+			<arg type="h" name="out_fd" direction="out"/>
+		</method>
+	</interface>
+	</node>
+	"""
+	def Hello(self, in_fd):
+		with os.fdopen(in_fd) as in_file:
+			in_file.seek(0)
+			assert(contents == in_file.read())
+			print("Received fd as in parameter ok")
+		with open(__file__) as out_file:
+			assert(contents == out_file.read())
+			return os.dup(out_file.fileno())
+
+bus = SessionBus()
+
+
+with bus.publish("baz.bar.Foo", TestObject()):
+	remote = bus.get("baz.bar.Foo")
+
+	def thread_func():
+		with open(__file__) as in_file:
+			assert(contents == in_file.read())
+			out_fd = remote.Hello(in_file.fileno())
+			with os.fdopen(out_fd) as out_file:
+				out_file.seek(0)
+				assert(contents == out_file.read())
+				print("Received fd as out argument ok")
+		loop.quit()
+
+	thread = Thread(target=thread_func)
+	thread.daemon = True
+
+	def handle_timeout():
+		exit("ERROR: Timeout.")
+
+	GLib.timeout_add_seconds(2, handle_timeout)
+
+	thread.start()
+	loop.run()
+	thread.join()


### PR DESCRIPTION
Closes
https://github.com/LEW21/pydbus/issues/42, https://github.com/LEW21/pydbus/issues/54

(Maybe of interest to anyone: the branch https://github.com/molobrakos/pydbus/tree/master%2Basync%2Bunixfd contains support for both unix file descriptors as well as the support for asynchronous calls by @poncova in (https://github.com/poncovka/pydbus/commit/5e2b4d2e32db8b8842188d8915f3932bae594cd5 - merging these two were a little bit messy since they are touching the same code)

Semantics for file descriptor ownership should probably be described in the documentation. Any file descriptor as `out` parameter will be closed by the dbus interface and should not be closed by the sender (just passed as `return`). Any file desciptor as `in`-parameter is only valid for the duration of the call and will be closed by the dbus interface. If the receiver wants to keep it, it should be duplicated using `os.dup`.