### PR TITLE
support installation from any folder, minor PEP8 cleanups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,39 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
+import os
+
+os.chdir(os.path.dirname(__file__))
 
 with open('README.rst') as f:
-	readme = f.read()
+    readme = f.read()
 
 setup(
-	name = "pydbus",
-	version = "0.6.0",
-	description = "Pythonic DBus library",
-	long_description = readme,
-	author = "Linus Lewandowski",
-	author_email = "linus@lew21.net",
-	url = "https://github.com/LEW21/pydbus",
-	keywords = "dbus",
-	license = "LGPLv2+",
+    name='pydbus',
+    version='0.6.0',
+    description='Pythonic DBus library',
+    long_description=readme,
+    author='Linus Lewandowski',
+    author_email='linus@lew21.net',
+    url='https://github.com/LEW21/pydbus',
+    keywords='dbus',
+    license='LGPLv2+',
 
-	packages = ["pydbus"],
-	package_data = {"": ["LICENSE"]},
-	package_dir = {"pydbus": "pydbus"},
-	zip_safe = True,
-	classifiers = [
-		'Development Status :: 5 - Production/Stable',
-		'Intended Audience :: Developers',
-		'Natural Language :: English',
-		'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
-		'Programming Language :: Python',
-		'Programming Language :: Python :: 3',
-		'Programming Language :: Python :: 3.3',
-		'Programming Language :: Python :: 3.4',
-		'Programming Language :: Python :: 3.5',
-		'Programming Language :: Python :: 2',
-		'Programming Language :: Python :: 2.7'
-	]
+    packages=['pydbus'],
+    package_data={'': ['LICENSE']},
+    package_dir={'pydbus': 'pydbus'},
+    zip_safe=True,
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7'
+    ]
 )


### PR DESCRIPTION
Currently, when installing from another folder than the root folder, installation fails because it does not find the README.rst file. This PR uses an abolute path.

Note that i also fixed some PEP8 warnings (replaced tabs by 4 spaces, removed spaces before =). I also replaced double quotes by single quotes everywhere for uniformity.

```
# python pydbus/setup.py install
Traceback (most recent call last):
  File "pydbus/setup.py", line 6, in <module>
    with open('README.rst') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'README.rst'
```