### PR TITLE
Adding Power support(ppc64le)with continuous integration/testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+arch:
+  - amd64
+  - ppc64le
 
 env:
   - distribution: ubuntu


### PR DESCRIPTION
I am working for IBM to port power on arch to travis build for the packages as CI.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model, For more info tag @gerrith3.


